### PR TITLE
Removed linking, as it is now done in aws-ami-container.

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -143,22 +143,6 @@ module.exports = function(config, logger) {
 
 
 
-  var targetList = function(system, containerId, linkTargets, cb) {
-    if (system.topology.containers[containerId].type === 'aws-ami') {
-      linkTargets.push(system.topology.containers[containerId].id);
-      cb();
-    }
-    else {
-      async.each(system.topology.containers[containerId].contains, function(containedId, next) {
-        targetList(system, containedId, linkTargets, function() {
-          next();
-        });
-      }, cb);
-    }
-  };
-
-
-
   /**
    * link the container to the target
    * target - target to deploy to
@@ -169,37 +153,9 @@ module.exports = function(config, logger) {
    * cb - complete callback
    */
   var link = function link(mode, target, system, containerDef, container, out, cb) {
-    var elb = new aws.ELB(config);
-    var linkTargets = [];
-
     logger.info('linking');
     out.stdout('linking');
-
-    out.preview({cmd: 'elb.registerInstancesWithLoadBalancer', host: null, user: null, keyPath: null});
-    if (mode === 'preview') {
-      cb(null);
-    }
-    else {
-      elb.describeLoadBalancers({LoadBalancerNames : [container.id]}, function(err, data) {
-        if (err) { return cb(err); }
-        if (data && data.LoadBalancerDescriptions && data.LoadBalancerDescriptions[0]) {
-          targetList(system, container.id, linkTargets, function() {
-            async.each(linkTargets, function(targetId, next) {
-              var linked = _.find(data.LoadBalancerDescriptions[0].Instances, function(instance) { return targetId === instance.InstanceId; });
-              if (!linked) {
-                elb.registerInstancesWithLoadBalancer({LoadBalancerName: container.id,
-                                                       Instances: [{InstanceId: system.topology.containers[targetId].nativeId}]}, function(err) {
-                  next(err);
-                });
-              }
-              else {
-                next();
-              }
-            }, cb);
-          });
-        }
-      });
-    }
+    cb();
   };
 
 


### PR DESCRIPTION
Tested with https://github.com/nearform/nscale-kernel/pull/92.