### PR TITLE
Set a more aggresive healthcheck.

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -77,7 +77,20 @@ module.exports = function(config, logger) {
               var c = _.find(system.topology.containers, function(cont) { return cont.id === container.id; });
               c.nativeId = data.DNSName;
               system.dirty = true;
-              cb(null, system);
+              var params = {
+                HealthCheck: {
+                  HealthyThreshold: 2,
+                  Interval: 30,
+                  Target: 'TCP:' + container.specific.Listeners[0].InstancePort,
+                  Timeout: 5,
+                  UnhealthyThreshold: 10
+                },
+                LoadBalancerName: container.id
+              };
+              elb.configureHealthCheck(params, function(err, data) {
+                if (err) { return cb(err); }
+                cb(null, system)
+              });
             });
           });
         }


### PR DESCRIPTION
@Nss please review.

This is needed for the elb to quickly react to changes in the autoscaling group.

Part of https://github.com/nearform/nscale-kernel/pull/101