### PR TITLE
Remove describeLoadBalancers call

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -55,67 +55,64 @@ module.exports = function(config, logger) {
       container.specific.Subnets = [config.defaultSubnetId];
     }
 
-    elb.describeLoadBalancers({}, function(err, data) {
-      if (err) { return cb(err); }
+    var loadBalancerName = container.id;
+    var nscaleSystemTag = system.name + '-' + system.topology.name;
+    var nscaleIdTag = nscaleSystemTag + '-' + loadBalancerName;
 
-      var loadBalancerNames = _.pluck(data.LoadBalancerDescriptions, 'LoadBalancerName');
-      var nscaleSystemTag = system.name + '-' + system.topology.name;
-      var nscaleIdTag = nscaleSystemTag + '-' + container.id;
+    elb.describeTags({LoadBalancerNames: [loadBalancerName]}, function (err, data) {
+      if (err) {
+        return cb(err);
+      }
 
-      elb.describeTags({LoadBalancerNames: loadBalancerNames}, function (err, data) {
-        if (err) {
-          return cb(err);
+      var match = _.chain(data.TagDescriptions)
+        .pluck('Tags')
+        .flatten()
+        .find(function (tag) {
+          return tag.Key === 'nscale-id' && tag.Value === nscaleIdTag;
+        })
+        .value();
+
+      if (!match) {
+        container.specific.LoadBalancerName = loadBalancerName;
+
+        if (mode === 'preview') {
+          out.preview({cmd: 'elb.createLoadBalancer(' + JSON.stringify(container.specific, null, 2) + ')', host: null, user: null, keyPath: null});
+          return cb(null, system);
         }
 
-        var match = _.chain(data.TagDescriptions)
-          .pluck('Tags')
-          .flatten()
-          .find(function (tag) {
-            return tag.Key === 'nscale-id' && tag.Value === nscaleIdTag;
-          })
-          .value();
+        elb.createLoadBalancer(container.specific, function(err, data) {
+          if (err) { return cb(err); }
 
-        if (!match) {
-          container.specific.LoadBalancerName = container.id;
+          var tagParams = {LoadBalancerNames: [container.specific.LoadBalancerName], Tags: []};
+          tagParams.Tags.push({Key: 'nscale-system', Value: nscaleSystemTag});
+          tagParams.Tags.push({Key: 'nscale-id', Value: nscaleIdTag});
+          tagParams.Tags.push({Key: 'Name', Value: loadBalancerName});
 
-          if (mode === 'preview') {
-            out.preview({cmd: 'elb.createLoadBalancer(' + JSON.stringify(container.specific, null, 2) + ')', host: null, user: null, keyPath: null});
-            return cb(null, system);
-          }
-
-          elb.createLoadBalancer(container.specific, function(err, data) {
+          elb.addTags(tagParams, function(err) {
             if (err) { return cb(err); }
-            var tagParams = {LoadBalancerNames: [container.specific.LoadBalancerName], Tags: []};
-            tagParams.Tags.push({Key: 'nscale-system', Value: nscaleSystemTag});
-            tagParams.Tags.push({Key: 'nscale-id', Value: nscaleIdTag});
-            tagParams.Tags.push({Key: 'Name', Value: container.id});
-            elb.addTags(tagParams, function(err) {
+            var c = _.find(system.topology.containers, function(cont) { return cont.id === container.id; });
+            c.nativeId = data.DNSName;
+            system.dirty = true;
+            var params = {
+              HealthCheck: {
+                HealthyThreshold: 2,
+                Interval: 30,
+                Target: 'TCP:' + container.specific.Listeners[0].InstancePort,
+                Timeout: 5,
+                UnhealthyThreshold: 10
+              },
+              LoadBalancerName: loadBalancerName
+            };
+            elb.configureHealthCheck(params, function(err, data) {
               if (err) { return cb(err); }
-              var c = _.find(system.topology.containers, function(cont) { return cont.id === container.id; });
-              c.nativeId = data.DNSName;
-              system.dirty = true;
-              var params = {
-                HealthCheck: {
-                  HealthyThreshold: 2,
-                  Interval: 30,
-                  Target: 'TCP:' + container.specific.Listeners[0].InstancePort,
-                  Timeout: 5,
-                  UnhealthyThreshold: 10
-                },
-                LoadBalancerName: container.id
-              };
-              elb.configureHealthCheck(params, function(err, data) {
-                if (err) { return cb(err); }
-                cb(null, system);
-              });
+              cb(null, system);
             });
           });
-        }
-        else {
-          cb(null, system);
-        }
-      });
-
+        });
+      }
+      else {
+        cb(null, system);
+      }
     });
   };
 


### PR DESCRIPTION
The describeLoadBalancers call is not needed because we already know
the loadBalancer name and we can just ask for Tags